### PR TITLE
Add warnings import, as numpy no longer exports it

### DIFF
--- a/pmoired/__init__.py
+++ b/pmoired/__init__.py
@@ -12,7 +12,8 @@ except:
     pass
 
 import numpy as np
-np.warnings.filterwarnings('ignore')
+import warnings
+warnings.filterwarnings('ignore')
 
 import matplotlib.pyplot as plt
 import scipy


### PR DESCRIPTION
Hi,

 Just a quick fix for the latest numpy releases. numpy no longer re-exports warnings, see numpy/numpy#21403, so warnings has to be explicitly imported.

Cheers,

Matthew Horrobin